### PR TITLE
fix: Response status code from start() of GuardAuthenticator is ignored 

### DIFF
--- a/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.js
+++ b/src/Symfony/Bundle/WebProfilerBundle/Resources/views/Collector/time.js
@@ -252,11 +252,11 @@ class Legend {
     }
 
     get(category) {
-        return this.categories.find(element => element.value === category);
+        return this.categories.find(element => element.value === category) || this.createCategory(category);
     }
 
     getClassname(category) {
-        return this.classnames[category];
+        return this.classnames[category] || '';
     }
 
     getSectionClassname() {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master for features / 3.4 up to 4.2 for bug fixes <!-- see below -->
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- see https://symfony.com/bc -->
| Deprecations? | yes/no <!-- don't forget to update UPGRADE-*.md and src/**/CHANGELOG.md files -->
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT
| Doc PR        | symfony/symfony-docs#... <!-- required for new features -->

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help people understand your PR and can be used as a start of the Doc PR.
Additionally:
 - Bug fixes must be submitted against the lowest branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too).
 - Features and deprecations must be submitted against the master branch.
-->
